### PR TITLE
Fix pbm_pitr_error always firing on newer versions of pbm

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -126,7 +126,7 @@ const updateStatus = async () => {
       let lock = await db.collection('pbmLock').findOne({ type: 'pitr' })
       debug('PITR lock', lock)
       if (!lock) {
-        lock = await db.collection('pbmOpLock').findOne({ type: 'pitr' })
+        lock = await db.collection('pbmLockOp').findOne({ type: 'pitr' })
         debug('PITR OP lock', lock)
       }
 

--- a/server/index.js
+++ b/server/index.js
@@ -123,8 +123,13 @@ const updateStatus = async () => {
 
     debug('PITR enabled', pbmConfig.pitr?.enabled)
     if (pbmConfig.pitr?.enabled) {
-      const lock = await db.collection('pbmLock').findOne({ type: 'pitr' })
+      let lock = await db.collection('pbmLock').findOne({ type: 'pitr' })
       debug('PITR lock', lock)
+      if (!lock) {
+        lock = await db.collection('pbmOpLock').findOne({ type: 'pitr' })
+        debug('PITR OP lock', lock)
+      }
+
       const now = Math.round(new Date().getTime() / 1000)
       const pitrStale = !lock || (lock.hb.high + 30) < now
       debug('PITR stale', pitrStale, lock && (now - lock.hb.high))


### PR DESCRIPTION
There's a new collection `pbmLockOp` to look into, in addition to `pbmLock`.

Closes https://github.com/koumoul-dev/pbm-exporter/issues/1